### PR TITLE
Add initial implementation of iob_dma module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 # iob-dma
+
+DMA for IObundle SoCs with:
+
+- **1 AXI manager data interface** (memory source/destination path)
+- **1 AXI-Lite subordinate control interface** (register programming and status)
+
+This repository contains the hardware module, software driver, and integration support files for simulation/embedding flows.
+
+## Overview
+
+`iob-dma` moves data from an AXI-full source address range to an AXI-full destination address range under software control.
+Software configures source/destination addresses, transfer length, and burst length through the control registers, then starts source-to-destination DMA operations.
+
+## DMA Operation
+
+- The DMA reads data from AXI source address space and writes it to AXI destination address space.
+- The internal datapath connects read-side output to write-side input, so no external AXI-Stream interface is required.
+- A single `start` triggers both source read and destination write paths.
+- `busy` remains high while the transfer is in progress.
+
+Example programming sequence:
+
+```c
+dma_init(DMA_BASEADDR);
+dma_start_transfer(src_addr, dst_addr, length_words, burstlen_words);
+while (dma_busy()) {
+	// wait
+}
+```
+
+## Main Interfaces
+
+### AXI manager data interface
+
+- Used for DMA transfers between AXI-full source and destination memory regions.
+- Configurable address, burst length, ID, and data width parameters.
+
+### AXI-Lite subordinate control interface
+
+- Used by CPU/software to configure and monitor the DMA.
+- Exposes control/status registers for source and destination addressing plus shared transfer control/status.
+
+## Register-Level Control
+
+The DMA exposes source and destination address registers, while transfer control/status fields use the same semantics for both paths:
+
+- Source address: `src_addr`
+- Destination address: `dst_addr`
+- Shared transfer fields: `length`, `burstlen`, `start`, `busy`, `buf_level`
+- `soft_reset`
+
+Typical sequence:
+
+1. Program `src_addr` and `dst_addr`.
+2. Program `length` and `burstlen`.
+3. Trigger `start`.
+4. Poll `busy` until transfer completes.
+
+## Software API
+
+Driver files are available in `software/src/`:
+
+- `iob-dma.h`
+- `iob-dma.c`
+
+Exposed helper functions:
+
+- `dma_init(...)`: initializes the DMA base address.
+- `dma_start_transfer(...)`: starts a source-to-destination transfer.
+- `dma_busy(...)`: reports transfer progress.
+
+```c
+void dma_init(int base_address);
+void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr, uint32_t length, uint32_t burstlen);
+uint8_t dma_busy();
+```
+
+## Repository Structure
+
+- `iob_dma.py`: DMA description and configurable parameters
+- `hardware/src/iob_dma.v`: top-level RTL
+- `software/src/`: C driver and software support

--- a/hardware/src/iob_dma.v
+++ b/hardware/src/iob_dma.v
@@ -1,0 +1,127 @@
+`timescale 1ns / 1ps
+
+`include "iob_dma_conf.vh"
+`include "iob_dma_swreg_def.vh"
+
+module iob_dma #(
+   `include "iob_dma_params.vs"
+) (
+   `include "iob_dma_io.vs"
+);
+
+   //BLOCK Register File & Configuration control and status register file.
+   `include "iob_dma_swreg_inst.vs"
+
+   // External memory interfaces
+   wire                  write_fifo_mem_clk;
+   wire                  write_fifo_mem_w_en;
+   wire [ AXI_LEN_W-1:0] write_fifo_mem_w_addr;
+   wire [AXI_DATA_W-1:0] write_fifo_mem_w_data;
+   wire                  write_fifo_mem_r_en;
+   wire [ AXI_LEN_W-1:0] write_fifo_mem_r_addr;
+   wire [AXI_DATA_W-1:0] write_fifo_mem_r_data;
+
+   wire                  read_fifo_mem_clk;
+   wire                  read_fifo_mem_w_en;
+   wire [ AXI_LEN_W-1:0] read_fifo_mem_w_addr;
+   wire [AXI_DATA_W-1:0] read_fifo_mem_w_data;
+   wire                  read_fifo_mem_r_en;
+   wire [ AXI_LEN_W-1:0] read_fifo_mem_r_addr;
+   wire [AXI_DATA_W-1:0] read_fifo_mem_r_data;
+
+   wire                  dst_busy;
+   wire                  src_busy;
+   wire [LENGTH_W-1:0]   dst_buf_level;
+   wire [LENGTH_W-1:0]   src_buf_level;
+
+   wire [AXI_DATA_W-1:0] dma_data;
+   wire                  dma_valid;
+   wire                  dma_ready;
+
+   assign soft_reset_ready_wr = 1'b1;
+   assign start_ready_wr      = 1'b1;
+   assign busy_rd             = src_busy | dst_busy;
+   assign buf_level_rd        = src_buf_level;
+
+   iob_axi_m #(
+      .AXI_ADDR_W(AXI_ADDR_W),
+      .AXI_LEN_W (AXI_LEN_W),
+      .AXI_DATA_W(AXI_DATA_W),
+      .AXI_ID_W  (AXI_ID_W),
+      .WLENGTH_W(LENGTH_W),
+      .RLENGTH_W(LENGTH_W)
+   ) axi_m_inst (
+      `include "clk_en_rst_s_s_portmap.vs"
+      .rst_i(soft_reset_wen_wr),
+
+      // AXI manager destination path
+      .w_addr_i          (dst_addr_wr),
+      .w_length_i        (length_wr),
+      .w_start_transfer_i(start_wen_wr),
+      .w_max_len_i       (burstlen_wr),
+      .w_remaining_data_o(dst_buf_level),
+      .w_busy_o          (dst_busy),
+
+      // AXI manager source path
+      .r_addr_i          (src_addr_wr),
+      .r_length_i        (length_wr),
+      .r_start_transfer_i(start_wen_wr),
+      .r_max_len_i       (burstlen_wr),
+      .r_remaining_data_o(src_buf_level),
+      .r_busy_o          (src_busy),
+
+      // Internal data path: source read stream to destination write stream
+      .axis_in_data_i (dma_data),
+      .axis_in_valid_i(dma_valid),
+      .axis_in_ready_o(dma_ready),
+
+      .axis_out_data_o (dma_data),
+      .axis_out_valid_o(dma_valid),
+      .axis_out_ready_i(dma_ready),
+
+      .w_ext_mem_clk_o   (write_fifo_mem_clk),
+      .w_ext_mem_w_en_o  (write_fifo_mem_w_en),
+      .w_ext_mem_w_addr_o(write_fifo_mem_w_addr),
+      .w_ext_mem_w_data_o(write_fifo_mem_w_data),
+      .w_ext_mem_r_en_o  (write_fifo_mem_r_en),
+      .w_ext_mem_r_addr_o(write_fifo_mem_r_addr),
+      .w_ext_mem_r_data_i(write_fifo_mem_r_data),
+
+      .r_ext_mem_clk_o   (read_fifo_mem_clk),
+      .r_ext_mem_w_en_o  (read_fifo_mem_w_en),
+      .r_ext_mem_w_addr_o(read_fifo_mem_w_addr),
+      .r_ext_mem_w_data_o(read_fifo_mem_w_data),
+      .r_ext_mem_r_en_o  (read_fifo_mem_r_en),
+      .r_ext_mem_r_addr_o(read_fifo_mem_r_addr),
+      .r_ext_mem_r_data_i(read_fifo_mem_r_data),
+
+      `include "axi_m_m_portmap.vs"
+   );
+
+   iob_ram_2p #(
+      .DATA_W(AXI_DATA_W),
+      .ADDR_W(AXI_LEN_W)
+   ) w_ext_memory (
+      .clk_i   (write_fifo_mem_clk),
+      .w_en_i  (write_fifo_mem_w_en),
+      .w_data_i(write_fifo_mem_w_data),
+      .w_addr_i(write_fifo_mem_w_addr),
+      .r_en_i  (write_fifo_mem_r_en),
+      .r_data_o(write_fifo_mem_r_data),
+      .r_addr_i(write_fifo_mem_r_addr)
+   );
+
+   iob_ram_2p #(
+      .DATA_W(AXI_DATA_W),
+      .ADDR_W(AXI_LEN_W)
+   ) r_ext_memory (
+      .clk_i   (read_fifo_mem_clk),
+      .w_en_i  (read_fifo_mem_w_en),
+      .w_data_i(read_fifo_mem_w_data),
+      .w_addr_i(read_fifo_mem_w_addr),
+      .r_en_i  (read_fifo_mem_r_en),
+      .r_data_o(read_fifo_mem_r_data),
+      .r_addr_i(read_fifo_mem_r_addr)
+   );
+
+endmodule

--- a/iob_dma.py
+++ b/iob_dma.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+import os
+
+from iob_module import iob_module
+
+# Submodules
+from iob_axi_m import iob_axi_m
+from iob_ram_2p import iob_ram_2p
+
+class iob_dma(iob_module):
+    name = "iob_dma"
+    version = "V0.20"
+    flows = "sim emb"
+    setup_dir = os.path.dirname(__file__)
+
+    @classmethod
+    def _create_submodules_list(cls):
+        """Create submodules list with dependencies of this module"""
+        super()._create_submodules_list(
+            [
+                {"interface": "clk_en_rst_s_port"},
+                {"interface": "clk_en_rst_s_s_portmap"},
+                {"interface": "iob_s_port"},
+                {"interface": "iob_s_portmap"},
+                {"interface": "axi_m_port"},
+                {"interface": "axi_m_m_portmap"},
+                iob_axi_m,
+                iob_ram_2p,
+            ]
+        )
+
+    @classmethod
+    def _setup_confs(cls):
+        super()._setup_confs(
+            [
+                # CSR interface
+                {
+                    "name": "DATA_W",
+                    "type": "F",
+                    "val": "32",
+                    "min": "NA",
+                    "max": "32",
+                    "descr": "Data bus width",
+                },
+                {
+                    "name": "ADDR_W",
+                    "type": "F",
+                    "val": "`IOB_DMA_SWREG_ADDR_W",
+                    "min": "NA",
+                    "max": "NA",
+                    "descr": "Address bus width",
+                },
+                # AXI interface
+                {
+                    "name": "AXI_ADDR_W",
+                    "type": "P",
+                    "val": "24",
+                    "min": "1",
+                    "max": "32",
+                    "descr": "AXI address bus width",
+                },
+                {
+                    "name": "AXI_LEN_W",
+                    "type": "P",
+                    "val": "8",
+                    "min": "1",
+                    "max": "8",
+                    "descr": "AXI burst length width",
+                },
+                {
+                    "name": "AXI_DATA_W",
+                    "type": "P",
+                    "val": "DATA_W",
+                    "min": "1",
+                    "max": "32",
+                    "descr": "AXI data bus width",
+                },
+                {
+                    "name": "AXI_ID_W",
+                    "type": "P",
+                    "val": "1",
+                    "min": "NA",
+                    "max": "NA",
+                    "descr": "AXI ID width",
+                },
+                {
+                    "name": "LENGTH_W",
+                    "type": "P",
+                    "val": "12",
+                    "min": "1",
+                    "max": "AXI_ADDR_W",
+                    "descr": "Transfer length width",
+                },
+            ]
+        )
+
+    @classmethod
+    def _setup_ios(cls):
+        cls.ios += [
+            {"name": "axil_s_port", "descr": "AXI-Lite subordinate CSRs interface", "ports": []},
+            {
+                "name": "general",
+                "descr": "General system signals",
+                "ports": [
+                    {
+                        "name": "clk_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System clock input",
+                    },
+                    {
+                        "name": "arst_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System reset, asynchronous and active high",
+                    },
+                    {
+                        "name": "cke_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System clock enable signal.",
+                    },
+                ],
+            },
+            {
+                "name": "axi_m_port",
+                "descr": "AXI manager interface for external memory.",
+                "ports": [],
+            },
+        ]
+
+    @classmethod
+    def _setup_regs(cls):
+        cls.regs += [
+            {
+                "name": "general",
+                "descr": "DMA general software accessible registers.",
+                "regs": [
+                    {
+                        "name": "soft_reset",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Soft reset: writing any value to this register resets DMA.",
+                    },
+                ],
+            },
+            {
+                "name": "transfer_config",
+                "descr": "DMA transfer software accessible registers.",
+                "regs": [
+                    {
+                        "name": "src_addr",
+                        "type": "W",
+                        "n_bits": "AXI_ADDR_W",
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Source start address.",
+                    },
+                    {
+                        "name": "dst_addr",
+                        "type": "W",
+                        "n_bits": "AXI_ADDR_W",
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Destination start address.",
+                    },
+                    {
+                        "name": "length",
+                        "type": "W",
+                        "n_bits": "LENGTH_W",
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Transfer length in words.",
+                    },
+                    {
+                        "name": "busy",
+                        "type": "R",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "DMA busy: high while a transfer is ongoing.",
+                    },
+                    {
+                        "name": "start",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Start transfer: writing any value starts the DMA transfer.",
+                    },
+                    {
+                        "name": "burstlen",
+                        "type": "W",
+                        "n_bits": "(AXI_LEN_W+1)",
+                        "rst_val": 16,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "AXI burst length for transfers.",
+                    },
+                    {
+                        "name": "buf_level",
+                        "type": "R",
+                        "n_bits": "LENGTH_W",
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Number of words left in the current DMA transfer.",
+                    },
+                ],
+            },
+        ]
+
+    @classmethod
+    def _setup_block_groups(cls):
+        cls.block_groups += []

--- a/software/src/iob-dma.c
+++ b/software/src/iob-dma.c
@@ -1,0 +1,23 @@
+#include "iob-dma.h"
+
+// DMA functions
+
+// Set DMA interface base address
+void dma_init(int base_address){
+  IOB_DMA_INIT_BASEADDR(base_address);
+}
+
+// Start a DMA transfer from source to destination.
+void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr, uint32_t length, uint32_t burst_len){
+  IOB_DMA_SET_src_addr((uint32_t)src_addr);
+  IOB_DMA_SET_dst_addr((uint32_t)dst_addr);
+  IOB_DMA_SET_length(length);
+  IOB_DMA_SET_burstlen(burst_len);
+  IOB_DMA_SET_start(1);
+}
+
+// Check if DMA is busy
+uint8_t dma_busy(){
+  return IOB_DMA_GET_busy();
+}
+

--- a/software/src/iob-dma.h
+++ b/software/src/iob-dma.h
@@ -1,0 +1,20 @@
+#ifndef _IOB_DMA_H_
+#define _IOB_DMA_H_
+
+#include <stdint.h>
+
+#include "iob_dma_swreg.h"
+
+// DMA functions
+
+// Set DMA base address and Verilog parameters
+void dma_init(int base_address);
+
+// Start a DMA source-to-destination transfer
+void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr,
+                        uint32_t length, uint32_t burst_len);
+
+// Check if DMA is busy
+uint8_t dma_busy();
+
+#endif //_IOB_DMA_H_

--- a/software/src/iob_dma_swreg_pc_emul.c
+++ b/software/src/iob_dma_swreg_pc_emul.c
@@ -1,0 +1,18 @@
+/* PC Emulation of PFSM peripheral */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "iob-dma.h"
+
+static uint32_t base;
+void IOB_DMA_INIT_BASEADDR(uint32_t addr) {
+	base = addr;
+}
+
+void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr, uint32_t length, uint32_t burst_len){
+}
+
+uint8_t dma_busy(){
+    return 0;
+}


### PR DESCRIPTION
Introduce the iob_dma module along with a README for project overview and usage instructions. Implement the hardware module in Verilog, a Python driver for configuration and API functions, and C header/source files for DMA operations. Include PC emulation for the DMA peripheral.