### PR TITLE
Add AXI response status handling to DMA module

### DIFF
--- a/hardware/src/iob_dma.v
+++ b/hardware/src/iob_dma.v
@@ -47,6 +47,49 @@ module iob_dma #(
    assign w_dma_ack_o          = w_dma_ack;
    assign r_dma_ack_o          = r_dma_ack;
 
+   // AXI response sticky status
+   wire [2-1:0] r_resp_dma;
+   wire [2-1:0] w_resp_dma;
+   reg  [2-1:0] r_resp_nxt;
+   reg  [2-1:0] w_resp_nxt;
+
+   assign r_resp_clear_ready_wr = 1'b1;
+   assign w_resp_clear_ready_wr = 1'b1;
+
+   always @* begin
+      if (r_resp_dma != 2'b00) begin
+         r_resp_nxt = r_resp_dma;
+      end else begin
+         r_resp_nxt = r_resp_rd;
+      end
+
+      if (w_resp_dma != 2'b00) begin
+         w_resp_nxt = w_resp_dma;
+      end else begin
+         w_resp_nxt = w_resp_rd;
+      end
+   end
+
+   iob_reg_r #(
+      .DATA_W (2),
+      .RST_VAL(2'b00)
+   ) r_resp_reg (
+      `include "clk_en_rst_s_s_portmap.vs"
+      .rst_i (r_resp_clear_wen_wr),
+      .data_i(r_resp_nxt),
+      .data_o(r_resp_rd)
+   );
+
+   iob_reg_r #(
+      .DATA_W (2),
+      .RST_VAL(2'b00)
+   ) w_resp_reg (
+      `include "clk_en_rst_s_s_portmap.vs"
+      .rst_i (w_resp_clear_wen_wr),
+      .data_i(w_resp_nxt),
+      .data_o(w_resp_rd)
+   );
+
    iob_axi_m_dma #(
       .AXI_ADDR_W (AXI_ADDR_W),
       .AXI_LEN_W  (AXI_LEN_W),
@@ -71,6 +114,7 @@ module iob_dma #(
       .w_burst_type_i     (dst_burst_type_wr),
       .w_remaining_data_o (buf_level_rd),
       .w_busy_o           (dst_busy),
+      .w_resp_o           (w_resp_dma),
 
       // AXI manager source path
       .r_addr_i           (src_addr_wr),
@@ -84,6 +128,7 @@ module iob_dma #(
       .r_burst_type_i     (src_burst_type_wr),
       .r_remaining_data_o (),
       .r_busy_o           (src_busy),
+      .r_resp_o           (r_resp_dma),
 
       // Internal data path: source read stream to destination write stream
       .axis_in_data_i (dma_data),

--- a/iob_dma.py
+++ b/iob_dma.py
@@ -6,7 +6,9 @@ from iob_module import iob_module
 
 # Submodules
 from iob_axi_m_dma import iob_axi_m_dma
+from iob_reg_r import iob_reg_r
 from iob_ram_2p import iob_ram_2p
+
 
 class iob_dma(iob_module):
     """IObundle DMA module.
@@ -38,6 +40,7 @@ class iob_dma(iob_module):
                 {"interface": "axi_m_port"},
                 {"interface": "axi_m_m_portmap"},
                 iob_axi_m_dma,
+                iob_reg_r,
                 iob_ram_2p,
             ]
         )
@@ -310,6 +313,48 @@ class iob_dma(iob_module):
                         "log2n_items": 0,
                         "autoreg": True,
                         "descr": "Read DMA request pending status: high when a read DMA request is active and waiting for acknowledgment.",
+                    },
+                ],
+            },
+            {
+                "name": "response_status",
+                "descr": "AXI response status sticky registers.",
+                "regs": [
+                    {
+                        "name": "r_resp",
+                        "type": "R",
+                        "n_bits": 2,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Sticky AXI read response: holds the last non-OKAY code until r_resp_clear is written.",
+                    },
+                    {
+                        "name": "r_resp_clear",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Read response clear: writing any value clears the r_resp sticky register.",
+                    },
+                    {
+                        "name": "w_resp",
+                        "type": "R",
+                        "n_bits": 2,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Sticky AXI write response: holds the last non-OKAY code until w_resp_clear is written.",
+                    },
+                    {
+                        "name": "w_resp_clear",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": False,
+                        "descr": "Write response clear: writing any value clears the w_resp sticky register.",
                     },
                 ],
             },

--- a/software/src/iob-dma.c
+++ b/software/src/iob-dma.c
@@ -29,3 +29,19 @@ uint8_t dma_busy(){
   return IOB_DMA_GET_busy();
 }
 
+uint8_t dma_get_r_resp(){
+  return (uint8_t)IOB_DMA_GET_r_resp();
+}
+
+uint8_t dma_get_w_resp(){
+  return (uint8_t)IOB_DMA_GET_w_resp();
+}
+
+void dma_clear_r_resp(){
+  IOB_DMA_SET_r_resp_clear(1);
+}
+
+void dma_clear_w_resp(){
+  IOB_DMA_SET_w_resp_clear(1);
+}
+

--- a/software/src/iob-dma.h
+++ b/software/src/iob-dma.h
@@ -22,4 +22,12 @@ void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr,
 // Check if DMA is busy
 uint8_t dma_busy();
 
+// Get sticky AXI response status (OKAY=0, EXOKAY=1, SLVERR=2, DECERR=3)
+uint8_t dma_get_r_resp();
+uint8_t dma_get_w_resp();
+
+// Clear sticky AXI response status CSRs
+void dma_clear_r_resp();
+void dma_clear_w_resp();
+
 #endif //_IOB_DMA_H_

--- a/software/src/iob_dma_swreg_pc_emul.c
+++ b/software/src/iob_dma_swreg_pc_emul.c
@@ -16,3 +16,17 @@ void dma_start_transfer(uint32_t *src_addr, uint32_t *dst_addr, uint32_t transf_
 uint8_t dma_busy(){
     return 0;
 }
+
+uint8_t dma_get_r_resp(){
+	return 0;
+}
+
+uint8_t dma_get_w_resp(){
+	return 0;
+}
+
+void dma_clear_r_resp(){
+}
+
+void dma_clear_w_resp(){
+}


### PR DESCRIPTION
- Implement sticky registers for AXI read and write responses in Verilog.
- Update Python interface to include methods for accessing and clearing response statuses.
- Extend C header and source files with functions to get and clear AXI response statuses.